### PR TITLE
fix: ensure jQuery object exists before it is referenced

### DIFF
--- a/h5p-jquery-ui.js
+++ b/h5p-jquery-ui.js
@@ -1,4 +1,8 @@
-var oldJQuery = jQuery;
+var oldJQuery;
+if (window.jQuery !== undefined) {
+    oldJQuery = jQuery;
+}
+
 jQuery = H5P.jQuery;
 
 /*! jQuery UI - v1.10.2 - 2013-03-14


### PR DESCRIPTION
Do not assign the `jQuery` object to the `oldJQuery` variable if the jQuery object does not exist on the current window scope.


fixes: #2