### PR TITLE
HFP-3501 Add support for touch event on Chrome

### DIFF
--- a/h5p-jquery-ui.js
+++ b/h5p-jquery-ui.js
@@ -19023,7 +19023,7 @@ var jQuery = H5P.jQuery;
 			} );
 			this.liveRegion.remove();
 		}
-	} );
+	});
 
 // DEPRECATED
 // TODO: Switch return back to widget declaration at top of file when this is removed
@@ -19045,13 +19045,7 @@ var jQuery = H5P.jQuery;
 	}
 
 	var widgetsTooltip = $.ui.tooltip;
-
-
-
-
-
-} );
-
+});
 
 /*!
  * jQuery UI Touch Punch 0.2.2

--- a/h5p-jquery-ui.js
+++ b/h5p-jquery-ui.js
@@ -19050,8 +19050,8 @@ var jQuery = H5P.jQuery;
 
 
 
-
 } );
+
 
 /*!
  * jQuery UI Touch Punch 0.2.2
@@ -19066,7 +19066,7 @@ var jQuery = H5P.jQuery;
 (function ($) {
 
 	// Detect touch support
-	$.support.touch = 'ontouchend' in document;
+	$.support.touch = ('ontouchend' in document || navigator.maxTouchPoints > 0);
 
 	// Ignore browsers without touch support
 	if (!$.support.touch) {
@@ -19122,7 +19122,6 @@ var jQuery = H5P.jQuery;
 	 * @param {Object} event The widget element's touchstart event
 	 */
 	mouseProto._touchStart = function (event) {
-
 		var self = this;
 
 		// Ignore the event if another widget is already being handled


### PR DESCRIPTION
Chrome v.70+ have removed ontouch events, thus `$.support.touch = 'ontouchend' in document` is not supported. This PR adds the necessary functionality to handle touch for Chrome users (windows). 